### PR TITLE
Cr 423 rabbit support for cucumber tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.8</version>
+      <version>0.0.9</version>
     </dependency>
 
     <dependency>
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>cucumber-common</artifactId>
-      <version>0.0.2</version>
+      <version>0.0.3</version>
     </dependency>
 
 


### PR DESCRIPTION
Bumped versions of Event Publisher and Cucumber Common. 

This is so that Cucumber tests (using Cucumber Common) can connect to Rabbit using the config file in Cucumber Common. 

Due to a bug in Common Service the Rabbit connection details could only be read from a file (and not from within a jar file). This bug was fixed in Common Service 0.0.3