### PR TITLE
Cr 423 rabbit support for cucumber tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.9</version>
+      <version>0.0.10</version>
     </dependency>
 
     <dependency>
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>cucumber-common</artifactId>
-      <version>0.0.3</version>
+      <version>0.0.4</version>
     </dependency>
 
 


### PR DESCRIPTION
Use latest versions of dependancies, so that RabbitHelper (from Cucumber Common) can be tested using the newly restructured rabbit config file.